### PR TITLE
update!: use master version of zig

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "zig-evdev",
-    .version = "0.0.0",
+    .version = "0.1.0",
 
     .paths = .{
         "build",
@@ -11,7 +11,7 @@
         "README.md",
     },
 
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
 
     .dependencies = .{
         .libevdev = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "zig-evdev",
+    .name = .evdev,
+    .fingerprint = 0x3796d87768aac4d6,
     .version = "0.1.0",
 
     .paths = .{

--- a/build/capture_out.zig
+++ b/build/capture_out.zig
@@ -25,6 +25,7 @@ pub fn main() !void {
     var out = try std.fs.cwd().createFile(outpath, .{});
     defer out.close();
     try out.writeAll(res.stdout);
+    try std.io.getStdErr().writer().writeAll(res.stderr);
 
     std.process.exit(res.term.Exited);
 }

--- a/build/gen_event.zig
+++ b/build/gen_event.zig
@@ -3,12 +3,12 @@ const c = @cImport(@cInclude("libevdev/libevdev.h"));
 const std = @import("std");
 
 pub fn main() !void {
-    @setEvalBranchQuota(200000);
+    @setEvalBranchQuota(220000);
     const allocator = std.heap.page_allocator;
 
     const consts = comptime b: {
         var consts: []const []const u8 = &.{};
-        for (@typeInfo(c).Struct.decls) |decl|
+        for (@typeInfo(c).@"struct".decls) |decl|
             consts = consts ++ &[_][]const u8{decl.name};
         break :b consts;
     };
@@ -93,13 +93,13 @@ pub fn main() !void {
         ) catch {};
 
         for (types) |typ| w.print(
-            \\    {0s}: {0s},
+            \\    {0s}: {0s}CODE,
             \\
         , .{typ}) catch {};
 
         inline for (types) |typ| {
             w.print(
-                \\    pub const {s} = enum(c_ushort) {{
+                \\    pub const {s}CODE = enum(c_ushort) {{
                 \\
             , .{typ}) catch {};
             defer w.print(
@@ -113,7 +113,7 @@ pub fn main() !void {
                 \\            return Code{{ .{s} = self }};
                 \\        }}
                 \\        pub fn getName(self: @This()) ?[]const u8 {{
-                \\            if (comptime @typeInfo(@This()).Enum.fields.len == 0) return null;
+                \\            if (comptime @typeInfo(@This()).@"enum".fields.len == 0) return null;
                 \\            return switch (self) {{
                 \\                inline else => |c| @tagName(c),
                 \\            }};

--- a/examples/ctrl2cap.zig
+++ b/examples/ctrl2cap.zig
@@ -36,7 +36,7 @@ pub fn main() !void {
             std.debug.print("{}\n", .{event});
             var out = event;
             switch (out.code) {
-                .KEY => |*k| switch (k.*) {
+                .key => |*k| switch (k.*) {
                     .KEY_CAPSLOCK => k.* = .KEY_LEFTCTRL,
                     .KEY_LEFTCTRL => k.* = .KEY_CAPSLOCK,
                     .KEY_Q => break :main,

--- a/src/Device.zig
+++ b/src/Device.zig
@@ -7,11 +7,11 @@ const module = @import("root.zig");
 const Event = module.Event;
 const Property = module.Property;
 
-const raw = @import("raw.zig");
+const rawModule = @import("raw.zig");
 
 const Device = @This();
 
-raw: raw.Device,
+raw: rawModule.Device,
 
 pub fn open(path: []const u8, flags: std.posix.O) !Device {
     return try Device.fromFd(try std.posix.open(path, flags, 0o444));
@@ -19,7 +19,7 @@ pub fn open(path: []const u8, flags: std.posix.O) !Device {
 
 pub fn fromFd(fd: c_int) !Device {
     return Device{
-        .raw = try raw.Device.fromFd(fd),
+        .raw = try rawModule.Device.fromFd(fd),
     };
 }
 
@@ -56,13 +56,13 @@ pub fn isSingleTouch(self: Device) bool {
 
 pub fn isGamepad(self: Device) bool {
     return self.hasEventCode(
-        .{ .KEY = Event.Code.KEY.BTN_GAMEPAD },
+        .{ .KEY = Event.Code.KEYCODE.BTN_GAMEPAD },
     );
 }
 
 pub fn isMouse(self: Device) bool {
     inline for ([_]Event.Code{
-        .{ .KEY = Event.Code.KEY.BTN_MOUSE },
+        .{ .KEY = Event.Code.KEYCODE.BTN_MOUSE },
         .{ .REL = .REL_X },
         .{ .REL = .REL_Y },
     }) |code| if (!self.hasEventCode(code)) return false;
@@ -168,7 +168,7 @@ test removeInvalidEvents {
     try std.testing.expectEqualSlices(Event, after, events.items);
 }
 
-const ReadFlags = raw.Device.ReadFlags;
+const ReadFlags = rawModule.Device.ReadFlags;
 
 fn nextEvent(self: Device, flags: c_uint) !?Event {
     return self.raw.nextEvent(flags);
@@ -202,7 +202,7 @@ pub fn hasEventCode(self: Device, code: Event.Code) bool {
     return self.raw.hasEventCode(code);
 }
 
-pub fn getAbsInfo(self: Device, axis: Event.Code.ABS) [*c]const raw.AbsInfo {
+pub fn getAbsInfo(self: Device, axis: Event.Code.ABSCODE) [*c]const rawModule.AbsInfo {
     return self.raw.getAbsInfo(axis);
 }
 
@@ -210,6 +210,6 @@ pub fn getNumSlots(self: Device) c_int {
     return self.raw.getNumSlots();
 }
 
-pub fn getRepeat(self: Device, repeat: Event.Code.REP) ?c_int {
+pub fn getRepeat(self: Device, repeat: Event.Code.REPCODE) ?c_int {
     return self.raw.getRepeat(repeat);
 }

--- a/src/Device.zig
+++ b/src/Device.zig
@@ -38,42 +38,42 @@ pub fn closeAndFree(self: Device) void {
 
 pub fn isMultiTouch(self: Device) bool {
     inline for ([_]Event.Code{
-        .{ .KEY = .BTN_TOUCH },
-        .{ .ABS = .ABS_MT_POSITION_X },
-        .{ .ABS = .ABS_MT_POSITION_Y },
+        .{ .key = .BTN_TOUCH },
+        .{ .abs = .ABS_MT_POSITION_X },
+        .{ .abs = .ABS_MT_POSITION_Y },
     }) |code| if (!self.hasEventCode(code)) return false;
     return 1 < self.getNumSlots() and !self.isGamepad();
 }
 
 pub fn isSingleTouch(self: Device) bool {
     inline for ([_]Event.Code{
-        .{ .KEY = .BTN_TOUCH },
-        .{ .ABS = .ABS_X },
-        .{ .ABS = .ABS_Y },
+        .{ .key = .BTN_TOUCH },
+        .{ .abs = .ABS_X },
+        .{ .abs = .ABS_Y },
     }) |code| if (!self.hasEventCode(code)) return false;
     return !self.isMultiTouch();
 }
 
 pub fn isGamepad(self: Device) bool {
     return self.hasEventCode(
-        .{ .KEY = Event.Code.KEYCODE.BTN_GAMEPAD },
+        .{ .key = Event.Code.KEY.BTN_GAMEPAD },
     );
 }
 
 pub fn isMouse(self: Device) bool {
     inline for ([_]Event.Code{
-        .{ .KEY = Event.Code.KEYCODE.BTN_MOUSE },
-        .{ .REL = .REL_X },
-        .{ .REL = .REL_Y },
+        .{ .key = Event.Code.KEY.BTN_MOUSE },
+        .{ .rel = .REL_X },
+        .{ .rel = .REL_Y },
     }) |code| if (!self.hasEventCode(code)) return false;
     return true;
 }
 
 pub fn isKeyboard(self: Device) bool {
     inline for ([_]Event.Code{
-        .{ .KEY = .KEY_SPACE },
-        .{ .KEY = .KEY_A },
-        .{ .KEY = .KEY_Z },
+        .{ .key = .KEY_SPACE },
+        .{ .key = .KEY_A },
+        .{ .key = .KEY_Z },
     }) |code| if (!self.hasEventCode(code)) return false;
     return true;
 }
@@ -87,7 +87,7 @@ pub fn readEvents(self: Device, dest: *ArrayList(Event)) !usize {
         ev = (try self.nextEvent(ReadFlags.NORMAL)).?;
         try dest.append(ev);
         const syn = switch (ev.code) {
-            .SYN => |e| e,
+            .syn => |e| e,
             else => continue,
         };
         if (syn == .SYN_REPORT) break;
@@ -113,7 +113,7 @@ fn removeInvalidEvents(events: *ArrayList(Event), start_index: usize) void {
     var idx = start_index;
     while (idx < events.items.len) : (idx += 1) {
         const syn = switch (events.items[idx].code) {
-            .SYN => |e| e,
+            .syn => |e| e,
             else => continue,
         };
         switch (syn) {
@@ -137,28 +137,28 @@ test removeInvalidEvents {
     const allocator = std.testing.allocator;
     // zig fmt: off
     const before: []const Event = &.{
-        .{ .code = .{ .ABS = .ABS_X },       .value = 9 },
-        .{ .code = .{ .ABS = .ABS_Y },       .value = 8 },
-        .{ .code = .{ .SYN = .SYN_REPORT },  .value = 0 },
+        .{ .code = .{ .abs = .ABS_X },       .value = 9 },
+        .{ .code = .{ .abs = .ABS_Y },       .value = 8 },
+        .{ .code = .{ .syn = .SYN_REPORT },  .value = 0 },
         // ---
-        .{ .code = .{ .ABS = .ABS_X },       .value = 10 },
-        .{ .code = .{ .ABS = .ABS_Y },       .value = 10 },
-        .{ .code = .{ .SYN = .SYN_DROPPED }, .value = 0 },
-        .{ .code = .{ .ABS = .ABS_Y },       .value = 15 },
-        .{ .code = .{ .SYN = .SYN_REPORT },  .value = 0 },
+        .{ .code = .{ .abs = .ABS_X },       .value = 10 },
+        .{ .code = .{ .abs = .ABS_Y },       .value = 10 },
+        .{ .code = .{ .syn = .SYN_DROPPED }, .value = 0 },
+        .{ .code = .{ .abs = .ABS_Y },       .value = 15 },
+        .{ .code = .{ .syn = .SYN_REPORT },  .value = 0 },
         // ---
-        .{ .code = .{ .ABS = .ABS_X },       .value = 11 },
-        .{ .code = .{ .KEY = .BTN_TOUCH },   .value = 0 },
-        .{ .code = .{ .SYN = .SYN_REPORT },  .value = 0 },
+        .{ .code = .{ .abs = .ABS_X },       .value = 11 },
+        .{ .code = .{ .key = .BTN_TOUCH },   .value = 0 },
+        .{ .code = .{ .syn = .SYN_REPORT },  .value = 0 },
     };
     const after: []const Event = &.{
-        .{ .code = .{ .ABS = .ABS_X },       .value = 9 },
-        .{ .code = .{ .ABS = .ABS_Y },       .value = 8 },
-        .{ .code = .{ .SYN = .SYN_REPORT },  .value = 0 },
+        .{ .code = .{ .abs = .ABS_X },       .value = 9 },
+        .{ .code = .{ .abs = .ABS_Y },       .value = 8 },
+        .{ .code = .{ .syn = .SYN_REPORT },  .value = 0 },
         // ---
-        .{ .code = .{ .ABS = .ABS_X },       .value = 11 },
-        .{ .code = .{ .KEY = .BTN_TOUCH },   .value = 0 },
-        .{ .code = .{ .SYN = .SYN_REPORT },  .value = 0 },
+        .{ .code = .{ .abs = .ABS_X },       .value = 11 },
+        .{ .code = .{ .key = .BTN_TOUCH },   .value = 0 },
+        .{ .code = .{ .syn = .SYN_REPORT },  .value = 0 },
     };
     // zig fmt: on
     var events = ArrayList(Event).init(allocator);
@@ -202,7 +202,7 @@ pub fn hasEventCode(self: Device, code: Event.Code) bool {
     return self.raw.hasEventCode(code);
 }
 
-pub fn getAbsInfo(self: Device, axis: Event.Code.ABSCODE) [*c]const rawModule.AbsInfo {
+pub fn getAbsInfo(self: Device, axis: Event.Code.ABS) [*c]const rawModule.AbsInfo {
     return self.raw.getAbsInfo(axis);
 }
 
@@ -210,6 +210,6 @@ pub fn getNumSlots(self: Device) c_int {
     return self.raw.getNumSlots();
 }
 
-pub fn getRepeat(self: Device, repeat: Event.Code.REPCODE) ?c_int {
+pub fn getRepeat(self: Device, repeat: Event.Code.REP) ?c_int {
     return self.raw.getRepeat(repeat);
 }

--- a/src/VirtualDevice.zig
+++ b/src/VirtualDevice.zig
@@ -5,14 +5,14 @@ const Device = module.Device;
 const Event = module.Event;
 const Property = module.Property;
 
-const rawnModule = @import("raw.zig");
+const rawModule = @import("raw.zig");
 
 const VirtualDevice = @This();
 
-raw: rawnModule.UInputDevice,
+raw: rawModule.UInputDevice,
 
 pub fn fromDevice(dev: Device) !VirtualDevice {
-    return .{ .raw = try rawnModule.UInputDevice.createFromDevice(dev.raw) };
+    return .{ .raw = try rawModule.UInputDevice.createFromDevice(dev.raw) };
 }
 
 pub fn destroy(self: VirtualDevice) void {
@@ -36,15 +36,15 @@ pub fn getDevNode(self: VirtualDevice) []const u8 {
 }
 
 pub const Builder = struct {
-    raw: rawnModule.Device,
+    raw: rawModule.Device,
 
     pub fn new() Builder {
-        return Builder{ .raw = rawnModule.Device.new() };
+        return Builder{ .raw = rawModule.Device.new() };
     }
 
     pub fn build(self: Builder) !VirtualDevice {
         defer self.raw.free();
-        return .{ .raw = try rawnModule.UInputDevice.createFromDevice(self.raw) };
+        return .{ .raw = try rawModule.UInputDevice.createFromDevice(self.raw) };
     }
 
     pub fn setName(self: *Builder, name: []const u8) void {
@@ -67,7 +67,7 @@ pub const Builder = struct {
         return self.raw.disableEventType(typ);
     }
 
-    pub fn enableEventCode(self: *Builder, code: Event.Code, data: ?rawnModule.Device.EventCodeData) !void {
+    pub fn enableEventCode(self: *Builder, code: Event.Code, data: ?rawModule.Device.EventCodeData) !void {
         return self.raw.enableEventCode(code, data);
     }
 
@@ -100,8 +100,8 @@ pub const Builder = struct {
             const code = codeField.intoCode(); // Event.Code
 
             if (src.hasEventCode(code)) try self.enableEventCode(code, switch (typ) {
-                .ABS => .{ .abs_info = src.getAbsInfo(codeField) },
-                .REP => .{ .repeat = &src.getRepeat(codeField).? },
+                .abs => .{ .abs_info = src.getAbsInfo(codeField) },
+                .rep => .{ .repeat = &src.getRepeat(codeField).? },
                 else => null,
             });
         }

--- a/src/VirtualDevice.zig
+++ b/src/VirtualDevice.zig
@@ -5,14 +5,14 @@ const Device = module.Device;
 const Event = module.Event;
 const Property = module.Property;
 
-const raw = @import("raw.zig");
+const rawnModule = @import("raw.zig");
 
 const VirtualDevice = @This();
 
-raw: raw.UInputDevice,
+raw: rawnModule.UInputDevice,
 
 pub fn fromDevice(dev: Device) !VirtualDevice {
-    return .{ .raw = try raw.UInputDevice.createFromDevice(dev.raw) };
+    return .{ .raw = try rawnModule.UInputDevice.createFromDevice(dev.raw) };
 }
 
 pub fn destroy(self: VirtualDevice) void {
@@ -36,15 +36,15 @@ pub fn getDevNode(self: VirtualDevice) []const u8 {
 }
 
 pub const Builder = struct {
-    raw: raw.Device,
+    raw: rawnModule.Device,
 
     pub fn new() Builder {
-        return Builder{ .raw = raw.Device.new() };
+        return Builder{ .raw = rawnModule.Device.new() };
     }
 
     pub fn build(self: Builder) !VirtualDevice {
         defer self.raw.free();
-        return .{ .raw = try raw.UInputDevice.createFromDevice(self.raw) };
+        return .{ .raw = try rawnModule.UInputDevice.createFromDevice(self.raw) };
     }
 
     pub fn setName(self: *Builder, name: []const u8) void {
@@ -67,7 +67,7 @@ pub const Builder = struct {
         return self.raw.disableEventType(typ);
     }
 
-    pub fn enableEventCode(self: *Builder, code: Event.Code, data: ?raw.Device.EventCodeData) !void {
+    pub fn enableEventCode(self: *Builder, code: Event.Code, data: ?rawnModule.Device.EventCodeData) !void {
         return self.raw.enableEventCode(code, data);
     }
 
@@ -76,11 +76,11 @@ pub const Builder = struct {
     }
 
     pub fn copyCapabilities(self: *Builder, src: Device) !void {
-        inline for (0..@typeInfo(Property).Enum.fields.len) |prop_u| {
+        inline for (0..@typeInfo(Property).@"enum".fields.len) |prop_u| {
             const prop: Property = @enumFromInt(prop_u);
             if (src.hasProperty(prop)) try self.enableProperty(prop);
         }
-        inline for (@typeInfo(Event.Type).Enum.fields) |field| {
+        inline for (@typeInfo(Event.Type).@"enum".fields) |field| {
             try self.copyEventCapabilities(src, @field(Event.Type, field.name));
         }
     }
@@ -95,7 +95,7 @@ pub const Builder = struct {
 
         @setEvalBranchQuota(2000);
         const CodeType = typ.CodeType();
-        inline for (@typeInfo(CodeType).Enum.fields) |field| {
+        inline for (@typeInfo(CodeType).@"enum".fields) |field| {
             const codeField = @field(CodeType, field.name); // Event.Code.{KEY,SYN,..}.XXX
             const code = codeField.intoCode(); // Event.Code
 

--- a/src/event_test.zig
+++ b/src/event_test.zig
@@ -6,34 +6,34 @@ const Event = @import("Event");
 test "Type.getName" {
     var ty: Event.Type = undefined;
 
-    ty = .SYN;
+    ty = .syn;
     try t.expectEqualStrings(ty.getName(), "EV_SYN");
 
-    ty = .FF_STATUS;
+    ty = .ff_status;
     try t.expectEqualStrings(ty.getName(), "EV_FF_STATUS");
 }
 
 test "Type.CodeType" {
-    try t.expectEqual(Event.Type.KEY.CodeType(), Event.Code.KEYCODE);
-    try t.expectEqual(Event.Type.MSC.CodeType(), Event.Code.MSCCODE);
+    try t.expectEqual(Event.Type.key.CodeType(), Event.Code.KEY);
+    try t.expectEqual(Event.Type.msc.CodeType(), Event.Code.MSC);
 }
 
 test "Code.getName" {
     var c: Event.Code = undefined;
 
-    c = .{ .SYN = .SYN_REPORT };
+    c = .{ .syn = .SYN_REPORT };
     try t.expectEqualStrings(c.getName().?, "SYN_REPORT");
 
-    c = Event.Code.PWRCODE.new(0).intoCode();
+    c = Event.Code.PWR.new(0).intoCode();
     try t.expectEqual(c.getName(), null);
 }
 
 test "Code.getType" {
-    try t.expectEqual((Event.Code{ .REL = .REL_X }).getType(), Event.Type.REL);
-    try t.expectEqual((Event.Code{ .LED = .LED_CAPSL }).getType(), Event.Type.LED);
+    try t.expectEqual((Event.Code{ .rel = .REL_X }).getType(), Event.Type.rel);
+    try t.expectEqual((Event.Code{ .led = .LED_CAPSL }).getType(), Event.Type.led);
 }
 
 test "Code.XXX.intoCode" {
-    try t.expectEqual(Event.Code.KEYCODE.KEY_1.intoCode(), Event.Code{ .KEY = .KEY_1 });
-    try t.expectEqual(Event.Code.PWRCODE.new(0).intoCode(), Event.Code.new(.PWR, 0));
+    try t.expectEqual(Event.Code.KEY.KEY_1.intoCode(), Event.Code{ .key = .KEY_1 });
+    try t.expectEqual(Event.Code.PWR.new(0).intoCode(), Event.Code.new(.pwr, 0));
 }

--- a/src/event_test.zig
+++ b/src/event_test.zig
@@ -14,8 +14,8 @@ test "Type.getName" {
 }
 
 test "Type.CodeType" {
-    try t.expectEqual(Event.Type.KEY.CodeType(), Event.Code.KEY);
-    try t.expectEqual(Event.Type.MSC.CodeType(), Event.Code.MSC);
+    try t.expectEqual(Event.Type.KEY.CodeType(), Event.Code.KEYCODE);
+    try t.expectEqual(Event.Type.MSC.CodeType(), Event.Code.MSCCODE);
 }
 
 test "Code.getName" {
@@ -24,7 +24,7 @@ test "Code.getName" {
     c = .{ .SYN = .SYN_REPORT };
     try t.expectEqualStrings(c.getName().?, "SYN_REPORT");
 
-    c = Event.Code.PWR.new(0).intoCode();
+    c = Event.Code.PWRCODE.new(0).intoCode();
     try t.expectEqual(c.getName(), null);
 }
 
@@ -34,6 +34,6 @@ test "Code.getType" {
 }
 
 test "Code.XXX.intoCode" {
-    try t.expectEqual(Event.Code.KEY.KEY_1.intoCode(), Event.Code{ .KEY = .KEY_1 });
-    try t.expectEqual(Event.Code.PWR.new(0).intoCode(), Event.Code.new(.PWR, 0));
+    try t.expectEqual(Event.Code.KEYCODE.KEY_1.intoCode(), Event.Code{ .KEY = .KEY_1 });
+    try t.expectEqual(Event.Code.PWRCODE.new(0).intoCode(), Event.Code.new(.PWR, 0));
 }

--- a/src/raw.zig
+++ b/src/raw.zig
@@ -94,11 +94,11 @@ pub const Device = struct {
         return c.libevdev_has_event_code(self.dev, code.getType().intoInt(), code.intoInt()) == 1;
     }
 
-    pub inline fn getAbsInfo(self: Device, axis: Event.Code.ABSCODE) [*c]const AbsInfo {
+    pub inline fn getAbsInfo(self: Device, axis: Event.Code.ABS) [*c]const AbsInfo {
         return c.libevdev_get_abs_info(self.dev, axis.intoInt());
     }
 
-    pub fn getRepeat(self: Device, repeat: Event.Code.REPCODE) ?c_int {
+    pub fn getRepeat(self: Device, repeat: Event.Code.REP) ?c_int {
         var val: c_int = 0;
         return if (switch (repeat) {
             .REP_DELAY => c.libevdev_get_repeat(self.dev, &val, null),
@@ -226,7 +226,7 @@ pub const Device = struct {
                 const time: timeval = if (@hasField(timeval, "sec") and @hasField(timeval, "usec"))
                     .{ .sec = ev.time.tv_sec, .usec = ev.time.tv_usec }
                 else if (@hasField(timeval, "tv_sec") and @hasField(timeval, "tv_usec"))
-                    .{ .sec = ev.time.tv_sec, .usec = ev.time.tv_usec }
+                    .{ .tv_sec = ev.time.tv_sec, .tv_usec = ev.time.tv_usec }
                 else
                     @compileError("System architecture has unknown shape for std.posix.timeval");
 


### PR DESCRIPTION
Hello!

Loved the library, but had some issues to get it to work on latest the Zig version `0.14.0-dev.3237+ddff1fa4c`. I forked the project and made the necessary modification so I could use it on my project, and thought it might be helpful to see if these changes would be appreciated upstream.

Let me know if there is something that should change. Even if this is not accepted, I think this PR will be helpful when migrating to v0.14.0 that will be releasing on [March 3rd](https://ziglang.org/news/0.14.0-delayed/)

---
# Documenting the changes

There are two main breaking changes from Zig 0.13 to Zig master that prevented a successful compilation:

1. `std.builtin.Type` changed its fields. Instead of having a field `Struct`, it now has `@"struct"`. You can compare the changes from [v0.13.0](https://ziglang.org/documentation/0.13.0/std/#std.builtin.Type) to [master](https://ziglang.org/documentation/master/std/#std.builtin.Type). This means instead of doing `@typeInfo(c).Struct.decls` we'd do `@typeInfo(c).@"struct".decls`
2. Struct fields and declarations cannot have the same name anymore. This means the following code:
```zig
const t = struct {
    foo: u32,
    const foo = 10;
};
```
will result in the following error: `duplicate struct member name 'foo'`.
This also applies to module structs. So this file will also give the exact same error:
```zig
// bar.zig
foo: u32,
const foo = 10;
```
This is something that was heavily relied on in the `Event.zig` generated file. I then chose to rename all of the `pub const` decl, and append a `CODE` to their name. So `Event.Code.ABS` became `Event.Code.ABSCODE`. I don't think this is a good name or solution, so I'd encourage other suggestions.

3. This one is not because of the version upgrade, but it is still an issue. As shown in the stdlib, the implementation of [`std.posix.timeval`](https://ziglang.org/documentation/master/std/#std.posix.timeval) is system dependent. In some systems, such as [loogarch64](https://github.com/ziglang/zig/blob/d2e70ef84a912947f6485f6fc480030c2d6a8c8f/lib/std/os/linux/loongarch64.zig#L163), the `timeval` struct has the items `tv_sec` and `tv_usec` fields, while [x86_64](https://github.com/ziglang/zig/blob/master/lib/std/os/linux/x86_64.zig#L298) has `sec` and `usec` fields. I used a bit of Zig's `comptime` to solve this issue.
4. In `build/gen_event.zig`, it seems the newest versions require an increase in the `@setEvalBranchQuota`. 220000 seemed to work fine for me.

There is also a very small change in `build/capture_out.zig` to pipe the child's `stderr` to the parent's `stderr`. This is simply to improve debugging.